### PR TITLE
Added ability to manipulate activation scope

### DIFF
--- a/news/1.bugfix
+++ b/news/1.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug which caused ``VirtualEnv.sys_path`` to fail to populate correctly.

--- a/news/2.feature
+++ b/news/2.feature
@@ -1,0 +1,3 @@
+- Added ``VirtualEnv.resolve_dist(dist, working_set)`` to find the resolution set for a distribution on the specified working set.
+- Added ``VirtualEnv.initial_working_set`` which finds the working set based on the prefix according to ``sysconfig``.
+- Added the ability to pass ``extra_dists=[]`` to ``VirtualEnv.activated()`` in order to add dists to the activation scope for import in code.


### PR DESCRIPTION
- Add packages to the scope with a list of distributions
- Access `virtualenv.inital_working_set` which uses the `sysconfig`
  prefix value
- Resolve the dependencies of a distribution given a working set using
  `virtualenv.resolve_dist(dist, working_set)` for a set of dists to pass
  to `virtualenv.activated(extra_dists=[])`
- Fixes #1
- Fixes #2

Signed-off-by: Dan Ryan <dan@danryan.co>