### PR TITLE
Remove passa references and add base working_set

### DIFF
--- a/news/7.bugfix.rst
+++ b/news/7.bugfix.rst
@@ -1,0 +1,1 @@
+Removed references to and attempted imports of ``passa`` builder and installer functionality from ``VirtualEnv`` implementation in favor of ``packagebuilder`` and ``installer``.

--- a/news/8.feature.rst
+++ b/news/8.feature.rst
@@ -1,0 +1,1 @@
+``VirtualEnv`` instances will now create a reference to the outer ``pkg_resources.WorkingSet`` at instantiation and store it in ``VirtualEnv.base_working_set``.

--- a/news/9.bugfix.rst
+++ b/news/9.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue which caused errors on python versions 2.7-3.6 when attempting to uninstall packages in the virtualenv due to failed import attempts when using ``pip-shims.req_install``.

--- a/src/mork/virtualenv.py
+++ b/src/mork/virtualenv.py
@@ -11,7 +11,7 @@ import re
 import sys
 import sysconfig
 
-import distlib.wheel.Wheel
+import distlib.wheel
 import six
 
 from cached_property import cached_property
@@ -434,9 +434,12 @@ class VirtualEnv(object):
         :rtype: :class:`pip._internal.req.req_uninstall.UninstallPathset`
         """
 
-        from pip_shims.shims import req_install
-        req_uninstall_name = "{0}.req_uninstall".format(req_install.__package__)
-        req_uninstall = self.safe_import(req_uninstall_name)
+        from pip_shims.shims import InstallRequirement
+        # Determine the path to the uninstall module name based on the install module name
+        uninstall_path = InstallRequirement.__module__.replace(
+            "req_install", "req_uninstall"
+        )
+        req_uninstall = self.safe_import(uninstall_path)
         self.recursive_monkey_patch.monkey_patch(
             PatchedUninstaller, req_uninstall.UninstallPathSet
         )


### PR DESCRIPTION
- Remove all attempts to reference or import `passa` inside the venv
- Create and store `VirtualEnv.base_working_set` at instantiation
- Fixes #7
- Fixes #8

Signed-off-by: Dan Ryan <dan@danryan.co>