### PR TITLE
Fix path normalization and location determination

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     PIP_NO_INPUT=1
 
 install:
-  - "python -m pip install --upgrade pip pytest-timeout"
+  - "python -m pip install --upgrade pip pytest-timeout setuptools"
   - "python -m pip install -e .[tests]"
 script:
   - "python -m pytest -v -n 8 tests/"
@@ -35,7 +35,7 @@ jobs:
     - stage: coverage
       python: "3.6"
       install:
-        - "python -m pip install --upgrade pip pytest-timeout pytest-cov"
+        - "python -m pip install --upgrade pip setuptools pytest-timeout pytest-cov"
         - "python -m pip install --upgrade -e .[tests]"
       script:
         - "python -m pytest -n auto --timeout 300 --cov=mork --cov-report=term-missing --cov-report=xml --cov-report=html tests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ environment:
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - "python --version"
-  - "python -m pip install --upgrade pip"
-  - "python -m pip install -e .[tests]"
+  - "python -m pip install --upgrade pip setuptools pytest-timeout pytest-xdist"
+  - "python -m pip install -e .[tests,virtualenv]"
 
 build: off
 

--- a/news/11.bugfix.rst
+++ b/news/11.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with path locations which caused cross platform virtualenv operations to fail on windows.

--- a/src/mork/virtualenv.py
+++ b/src/mork/virtualenv.py
@@ -159,8 +159,7 @@ class VirtualEnv(object):
         python_path = next(iter(list(include_dir.iterdir())), None)
         if python_path and python_path.name.startswith("python"):
             python_version = python_path.name.replace("python", "")
-            python_version = python_version.replace(".", "")
-            py_version_short, abiflags = python_version[:2], python_version[2:]
+            py_version_short, abiflags = python_version[:3], python_version[3:]
             return {"py_version_short": py_version_short, "abiflags": abiflags}
         return {}
 

--- a/src/mork/virtualenv.py
+++ b/src/mork/virtualenv.py
@@ -27,7 +27,7 @@ class VirtualEnv(object):
         self.base_working_set = pkg_resources.WorkingSet(sys_module.path)
         own_dist = pkg_resources.get_distribution(pkg_resources.Requirement("mork"))
         self.extra_dists = self.resolve_dist(own_dist, self.base_working_set)
-        self._modules = {}
+        self._modules = {'pkg_resources': pkg_resources}
         try:
             self.recursive_monkey_patch = self.safe_import("recursive_monkey_patch")
         except ImportError:
@@ -158,7 +158,7 @@ class VirtualEnv(object):
         include_dir = self.venv_dir / "include"
         python_path = next(iter(list(include_dir.iterdir())), None)
         if python_path and python_path.name.startswith("python"):
-            python_version = python_path.replace("python", "")
+            python_version = python_path.name.replace("python", "")
             python_version = python_version.replace(".", "")
             py_version_short, abiflags = python_version[:2], python_version[2:]
             return {"py_version_short": py_version_short, "abiflags": abiflags}

--- a/src/mork/virtualenv.py
+++ b/src/mork/virtualenv.py
@@ -174,9 +174,9 @@ class VirtualEnv(object):
         config = {
             "base": prefix,
             "installed_base": prefix,
+            "platbase": prefix,
+            "installed_platbase": prefix
         }
-        if os.name != "nt":
-            config["installed_platbase"] = sysconfig.get_config_var("installed_platbase")
         config.update(self.pyversion)
         paths = {
             k: v.format(**config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 import mork
+import os
 import sys
 import vistir
 
@@ -20,6 +21,10 @@ def virtualenv(tmpdir_factory):
 
 
 @pytest.fixture
-def tmpvenv(virtualenv):
+def tmpvenv(virtualenv, tmpdir):
     venv_path = vistir.compat.Path(virtualenv.strpath).as_posix()
-    return mork.virtualenv.VirtualEnv(venv_path)
+    with vistir.contextmanagers.temp_environ():
+        os.environ["PACKAGEBUILDER_CACHE_DIR"] = tmpdir.strpath
+        yield mork.virtualenv.VirtualEnv(venv_path)
+    if "PACKAGEBUILDER_CACHE_DIR" in os.environ:
+        del os.environ["PACKAGEBUILDER_CACHE_DIR"]

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -69,27 +69,34 @@ def test_properties(tmpvenv):
     assert scripts_dir == vistir.compat.Path(tmpvenv.scripts_dir).as_posix()
     python = "{0}/python".format(tmpvenv.venv_dir.joinpath(script_basedir).as_posix())
     assert python == tmpvenv.python
+    libdir = "Lib" if os.name == "nt" else "lib"
+    libdir = tmpvenv.venv_dir.joinpath(libdir).as_posix().lower()
     assert any(
-        pth.startswith(tmpvenv.venv_dir.joinpath("lib").as_posix())
+        vistir.compat.Path(pth).as_posix().lower().startswith(libdir)
         for pth in tmpvenv.sys_path
-    )
+    ),  list(tmpvenv.sys_path)
     assert tmpvenv.sys_prefix == tmpvenv.venv_dir.as_posix()
 
 
 def test_install(tmpvenv):
     import requirementslib
     requests = requirementslib.Requirement.from_line("requests")
+    pytz = requirementslib.Requirement.from_line("pytz")
     retcode = tmpvenv.install(requests)
     assert retcode == 0
+    retcode = tmpvenv.install(pytz)
+    assert retcode == 0
     assert tmpvenv.is_installed("requests")
+    assert tmpvenv.is_installed("pytz")
     venv_dists = [dist for dist in tmpvenv.get_distributions()]
     venv_workingset = [dist for dist in tmpvenv.get_working_set()]
-    assert "requests" in [dist.project_name for dist in venv_dists]
-    assert "requests" in [dist.project_name for dist in venv_workingset]
+    expected = ["requests", "pytz"]
+    assert all(pkg in [dist.project_name for dist in venv_dists] for pkg in expected)
+    assert all(pkg in [dist.project_name for dist in venv_workingset] for pkg in expected)
     with tmpvenv.activated():
-        tmp_requests = tmpvenv.safe_import("requests")
-        requests_path = vistir.compat.Path(tmp_requests.__path__[0]).as_posix()
-        assert requests_path.startswith(tmpvenv.venv_dir.as_posix())
+        tmp_pytz = tmpvenv.safe_import("pytz")
+        pytz_path = vistir.compat.Path(tmp_pytz.__path__[0]).as_posix()
+        assert pytz_path.startswith(tmpvenv.venv_dir.as_posix()), pytz_path
 
 
 def test_uninstall(tmpvenv):
@@ -109,9 +116,13 @@ def test_uninstall(tmpvenv):
         dist for dist in tmpvenv.get_distributions()
         if dist.project_name == "requests"), None
     )
-    requests_deps = tmpvenv.resolve_dist(requests_dist, tmpvenv.get_working_set())
+    requests_deps = [
+        dist for dist in tmpvenv.resolve_dist(requests_dist, tmpvenv.get_working_set())
+        if dist is not None
+    ]
     uninstalled_packages = []
     for dep in requests_deps:
-        uninstalled_packages.extend(uninstall(dep.project_name))
+        uninstalled = uninstall(dep.project_name)
+        uninstalled_packages.extend(uninstalled)
     assert uninstalled_packages
     assert all(pkg.project_name in uninstalled_packages for pkg in requests_deps)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -42,8 +42,7 @@ def test_normpath(input_path, normalized, monkeypatch):
 
 
 def test_get_dists(tmpvenv):
-    dists = tmpvenv.get_distributions()
-    dist_names = [dist.project_name for dist in dists]
+    dist_names = [dist.project_name for dist in tmpvenv.get_distributions()]
     assert all(pkg in dist_names for pkg in ['setuptools', 'pip', 'wheel']), dist_names
 
 


### PR DESCRIPTION
- Use sysconfig to find locations on all platforms
- Normalize all paths using `vistir.compat.Path`
- Fixes #11

Signed-off-by: Dan Ryan <dan@danryan.co>